### PR TITLE
[CLD-14] FEATURE : Argo CD 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ test-results/
 
 infra/config/cognito-common.yml
 # Helm Values with Secrets
-eks/dh/ticketing-chart/values.yaml
+
 
 # Terraform
 .terraform/
@@ -99,3 +99,10 @@ eks/dh/ticketing-chart/values.yaml
 # Temporary/Backup folders
 eks/dh/copy/
 eks/dh/anti/
+
+# Documentation (Local only)
+eks/dh/ARGOCD_SECRETS.md
+eks/dh/ARGOCD_USAGE.md
+
+eks/dh/backend-ci-template.yaml
+eks/dh/CI_CD_GUIDE.md

--- a/eks/dh/argocd/argocd-application.yaml
+++ b/eks/dh/argocd/argocd-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ddcn4-1/terraform-v3.git
-    targetRevision: HEAD
+    targetRevision: eks-dh
     path: eks/dh/ticketing-chart
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
### PR 타입

FEATURE : Argo CD 연동

### 반영 브랜치

CLD-14 -> eks-dh 

### 변경 사항

- Argo CD 연동: argocd-application.yaml의 GitOps 파이프라인 정상화.

   > targetRevision을 HEAD에서 eks-dh로 변경.

- 보안 강화: .gitignore를 업데이트하여 로컬 가이드 문서 및 시크릿 관련 파일이 Git에 올라가지 않도록 설정.


### 테스트 결과

Argo CD UI에서 ticketing-app이 Synced 및 Healthy 상태인지 확인.
<img width="1375" height="702" alt="image" src="https://github.com/user-attachments/assets/b84dddb7-3211-4cf2-9749-9af34349537a" />


Closes #12 
